### PR TITLE
Get working on 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
     id 'org.cadixdev.licenser' version '0.6.1'
 }
 
@@ -9,23 +9,23 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = "LibNetworkStack"
-version = "0.6.3"
+version = "0.7.0"
 
 license {
     header = project.file('misc/LICENSE_HEADER.txt');
     newLine = false;
 }
 
-minecraft {
+loom {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.18.2"
-    mappings "net.fabricmc:yarn:1.18.2+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.13.3"
+    minecraft "com.mojang:minecraft:1.19"
+    mappings "net.fabricmc:yarn:1.19+build.1:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.7"
 
     //Fabric api
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.47.8+1.18.2"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.55.3+1.19"
 
     // Misc
     compileOnly "com.google.code.findbugs:jsr305:3.0.1"
@@ -57,13 +57,7 @@ tasks.withType(JavaCompile) {
     it.options.release = 17
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
+java.withSourcesJar()
 
 publishing {
     repositories {
@@ -87,7 +81,7 @@ ext.mavenGroupId = "alexiil.mc.lib";
 ext.extra_jar_def__optimised_compression = true;
 ext.extra_jar_def__common_manifest.put(null, ['Sealed': 'true']);
 
-generateJar("base", ["**"], [], true);
+ext.generateJar("base", ["**"], [], true);
 
 tasks.withType(AbstractArchiveTask) {
     preserveFileTimestamps = false

--- a/extra_jar_def.gradle
+++ b/extra_jar_def.gradle
@@ -466,8 +466,8 @@ def generateJarInternal(
 
     task("submod_" + key + "Jar", type: Jar, dependsOn: "writeFabricModJson_" + key) {
 
-        baseName = "$mainName-$key";
-        destinationDir = extra_jar_def__modulesDir;
+        archiveBaseName = "$mainName-$key";
+        destinationDirectory = extra_jar_def__modulesDir;
 
         from(getFabricModJsonFile(key).parentFile);
         for (nKey in nestedJars) {
@@ -519,8 +519,8 @@ def generateJarInternal(
                 }
             }
         }
-        destinationDir getStrippedJarFile(key).parentFile;
-        archiveName "$mainName-$key-stripped-${project.version}.jar";
+        destinationDirectory = getStrippedJarFile(key).parentFile;
+        archiveFileName = "$mainName-$key-stripped-${project.version}.jar";
     }
 
     task("submod_" + key + "SourcesJar", type: Jar, dependsOn: [unzipSourcesJar, "writeFabricModJson_" + key]) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Gradle keeps running out of heap space
+org.gradle.jvmargs=-Xmx1G

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/alexiil/mc/lib/net/ActiveConnection.java
+++ b/src/main/java/alexiil/mc/lib/net/ActiveConnection.java
@@ -14,9 +14,6 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.fabric.api.network.PacketContext;
-
 import net.minecraft.entity.player.PlayerEntity;
 
 import alexiil.mc.lib.net.impl.ActiveMinecraftConnection;
@@ -98,25 +95,18 @@ public abstract class ActiveConnection {
         }
     }
 
-    /** @return The Fabric API {@link PacketContext} for this connection. Throws an error if this is not a
-     *         {@link ActiveMinecraftConnection}. (Although mods will *never* need to worry about that unless they
-     *         create their own netty layer for a completely different connection).
-     * @deprecated Replaced by the specific methods {@link #getPlayer()} and {@link #getNetSide()}. */
-    @Deprecated
-    public abstract PacketContext getMinecraftContext();
-
     /** @return The "side" of this connection. If this is an {@link ActiveMinecraftConnection} then this will be CLIENT
      *         both when writing client to server packets, and when reading packets sent from the server. (And SERVER
      *         both when writing server to client packets, and when reading client to server packets). Other connection
      *         types might throw an exception if they reuse LNS for a non-standard minecraft connection. */
     public EnumNetSide getNetSide() {
-        return getMinecraftContext().getPacketEnvironment() == EnvType.CLIENT ? EnumNetSide.CLIENT : EnumNetSide.SERVER;
+        throw new UnsupportedOperationException("This type of ActiveConnection does not support net-sides.");
     }
 
     /** @return The Minecraft {@link PlayerEntity} for this connection. Throws an error if this is not a
      *         {@link ActiveMinecraftConnection}. */
     public PlayerEntity getPlayer() {
-        return getMinecraftContext().getPlayer();
+        throw new UnsupportedOperationException("This type of ActiveConnection does not support players.");
     }
 
     /** @param packetId The packet ID that has been written out to the first int of the given buffer.

--- a/src/main/java/alexiil/mc/lib/net/impl/ActiveClientConnection.java
+++ b/src/main/java/alexiil/mc/lib/net/impl/ActiveClientConnection.java
@@ -7,9 +7,6 @@
  */
 package alexiil.mc.lib.net.impl;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.fabric.api.network.PacketContext;
-
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.render.RenderTickCounter;
@@ -17,7 +14,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.util.Util;
-import net.minecraft.util.thread.ThreadExecutor;
 
 import alexiil.mc.lib.net.EnumNetSide;
 import alexiil.mc.lib.net.NetByteBuf;
@@ -44,22 +40,6 @@ public class ActiveClientConnection extends ActiveMinecraftConnection {
     private double smoothedServerTickDelta = 0;
 
     public ActiveClientConnection(ClientPlayNetworkHandler netHandler) {
-        super(new PacketContext() {
-            @Override
-            public ThreadExecutor getTaskQueue() {
-                return MinecraftClient.getInstance();
-            }
-
-            @Override
-            public PlayerEntity getPlayer() {
-                return MinecraftClient.getInstance().player;
-            }
-
-            @Override
-            public EnvType getPacketEnvironment() {
-                return EnvType.CLIENT;
-            }
-        });
         this.netHandler = netHandler;
     }
 

--- a/src/main/java/alexiil/mc/lib/net/impl/ActiveMinecraftConnection.java
+++ b/src/main/java/alexiil/mc/lib/net/impl/ActiveMinecraftConnection.java
@@ -7,8 +7,6 @@
  */
 package alexiil.mc.lib.net.impl;
 
-import net.fabricmc.fabric.api.network.PacketContext;
-
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
 import net.minecraft.util.Identifier;
@@ -57,19 +55,8 @@ public abstract class ActiveMinecraftConnection extends BufferedConnection {
     private int theirCustomId = NET_ID_NOT_OPTIMISED;
     private boolean hasSentCustomId;
 
-    /** Replaced by the specific methods ({@link #getPlayer()}, {@link #getNetSide()}, and ) */
-    @Deprecated
-    public final PacketContext ctx;
-
-    public ActiveMinecraftConnection(PacketContext ctx) {
+    public ActiveMinecraftConnection() {
         super(McNetworkStack.ROOT, /* Drop after 3 seconds by default */ 3 * 20);
-        this.ctx = ctx;
-    }
-
-    @Override
-    @Deprecated
-    public PacketContext getMinecraftContext() {
-        return ctx;
     }
 
     /** @return The "side" of this connection. This will be {@link EnumNetSide#CLIENT} both when writing client to

--- a/src/main/java/alexiil/mc/lib/net/impl/ActiveServerConnection.java
+++ b/src/main/java/alexiil/mc/lib/net/impl/ActiveServerConnection.java
@@ -7,20 +7,15 @@
  */
 package alexiil.mc.lib.net.impl;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.fabric.api.network.PacketContext;
-
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Util;
-import net.minecraft.util.thread.ThreadExecutor;
 
 import alexiil.mc.lib.net.EnumNetSide;
 import alexiil.mc.lib.net.NetByteBuf;
-import alexiil.mc.lib.net.mixin.impl.ServerPlayNetworkHandlerAccessor;
 
 /** A connection on the server side to a specific {@link ServerPlayerEntity}. */
 public class ActiveServerConnection extends ActiveMinecraftConnection {
@@ -29,22 +24,6 @@ public class ActiveServerConnection extends ActiveMinecraftConnection {
     private long serverTick = Long.MIN_VALUE;
 
     public ActiveServerConnection(ServerPlayNetworkHandler netHandler) {
-        super(new PacketContext() {
-            @Override
-            public ThreadExecutor getTaskQueue() {
-                return ((ServerPlayNetworkHandlerAccessor) netHandler).libnetworkstack_getServer();
-            }
-
-            @Override
-            public PlayerEntity getPlayer() {
-                return netHandler.player;
-            }
-
-            @Override
-            public EnvType getPacketEnvironment() {
-                return EnvType.SERVER;
-            }
-        });
         this.netHandler = netHandler;
     }
 

--- a/src/main/java/alexiil/mc/lib/net/impl/CompactDataPacketToServer.java
+++ b/src/main/java/alexiil/mc/lib/net/impl/CompactDataPacketToServer.java
@@ -7,11 +7,7 @@
  */
 package alexiil.mc.lib.net.impl;
 
-import java.io.IOException;
-
 import io.netty.buffer.Unpooled;
-
-import net.fabricmc.fabric.api.network.PacketContext;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayNetworkHandler;

--- a/src/main/java/alexiil/mc/lib/net/impl/McNetworkStack.java
+++ b/src/main/java/alexiil/mc/lib/net/impl/McNetworkStack.java
@@ -54,7 +54,7 @@ public final class McNetworkStack {
             @Override
             public BlockEntity readContext(NetByteBuf buffer, IMsgReadCtx ctx) throws InvalidInputDataException {
                 ActiveMinecraftConnection mcConn = (ActiveMinecraftConnection) ctx.getConnection();
-                PlayerEntity player = mcConn.ctx.getPlayer();
+                PlayerEntity player = mcConn.getPlayer();
                 return player.world.getBlockEntity(buffer.readBlockPos());
             }
 
@@ -71,7 +71,7 @@ public final class McNetworkStack {
             @Override
             public Entity readContext(NetByteBuf buffer, IMsgReadCtx ctx) throws InvalidInputDataException {
                 ActiveMinecraftConnection mcConn = (ActiveMinecraftConnection) ctx.getConnection();
-                PlayerEntity player = mcConn.ctx.getPlayer();
+                PlayerEntity player = mcConn.getPlayer();
                 return player.world.getEntityById(buffer.readInt());
             }
 
@@ -85,7 +85,7 @@ public final class McNetworkStack {
             @Override
             public ScreenHandler readContext(NetByteBuf buffer, IMsgReadCtx ctx) throws InvalidInputDataException {
                 ActiveMinecraftConnection mcConn = (ActiveMinecraftConnection) ctx.getConnection();
-                PlayerEntity player = mcConn.ctx.getPlayer();
+                PlayerEntity player = mcConn.getPlayer();
                 int syncId = buffer.readInt();
                 ScreenHandler currentContainer = player.currentScreenHandler;
                 if (currentContainer == null || currentContainer.syncId != syncId) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
     ]
   },
   "depends": {
-    "minecraft": [ ">=1.18.2 <1.19-" ],
+    "minecraft": [ ">=1.19 <1.20-" ],
     "fabricloader": ">=0.4.0",
     "fabric": "*"
   },

--- a/src/test/java/alexiil/mc/lib/net/test/SimpleNetTester.java
+++ b/src/test/java/alexiil/mc/lib/net/test/SimpleNetTester.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 
-import net.fabricmc.fabric.api.network.PacketContext;
-
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntity;
 
@@ -51,11 +49,6 @@ public class SimpleNetTester {
         private TestConnection(ParentNetId rootId, int id) {
             super(rootId);
             this.id = id;
-        }
-
-        @Override
-        public PacketContext getMinecraftContext() {
-            throw new IllegalStateException("This isn't a minecraft connection!");
         }
 
         @Override


### PR DESCRIPTION
# This PR
This pull request first, updates the buildscript to be compatible with the more-recent versions of loom that support Minecraft 1.19. And second, updates the code to be compatible with Minecraft 1.19 and associated libraries.

One of the code updates is that fabric-networking-v0 dependence has been removed.

# Testing
I have tested this in both gradle and as a dependency for a mod I am in the process of updating to 1.19. Everything seemed to work correctly.