### PR TITLE
Apply LMP multi-jar creation plugin fixes

### DIFF
--- a/extra_jar_def.gradle
+++ b/extra_jar_def.gradle
@@ -135,6 +135,8 @@ generateJar("items", itemsReq, [], false, [], ["core"]);
 // 2019/12/20 AlexIIL: Fix including all versions of the jars (including old versions if "gradle clean" hasn't been run)
 // 2020/01/23 AlexIIL: Add "fat" jars and the option for optimised compression.
 // 2020/02/22 AlexIIL: Added better error handling when generating fabric.mod.json files.
+// 2021/06/05 AlexIIL: Fixed a few missing task dependencies in gradle 7.
+// 2022/06/23 AlexIIL: Changed input jar (for nested jar extractions) to use remapJar directly, rather than just "jar"
 
 // ==========================================================
 // User config - change both of these on a per-project basis
@@ -182,7 +184,7 @@ ext.extra_jar_def__decompress_external_included = false;
 // Internals - don't touch this!
 // ==============================
 
-ext.extra_jar_def__jarFile = zipTree(jar.archivePath)
+ext.extra_jar_def__jarFile = zipTree(remapJar.archivePath)
 ext.extra_jar_def__modulesDir = new File(System.getenv("LIBS_DIR") ?: "$projectDir/build/libs/", version)
 ext.extra_jar_def__taken = new HashSet<>();
 ext.extra_jar_def__includedJarTasks = new HashSet<String>();
@@ -228,7 +230,7 @@ def getExpandedJarContentsFolder(String name) {
 }
 
 ext.extra_jar_def__unzippedSourceJar = new File("$projectDir/build/processing/tasks/unzipped_src_jar/unzip")
-task unzipSourcesJar(type: Copy, dependsOn: sourcesJar) {
+task unzipSourcesJar(type: Copy, dependsOn: remapSourcesJar) {
     from (zipTree(sourcesJar.archivePath)) {
         include "**"
     }
@@ -464,7 +466,7 @@ def generateJarInternal(
         }
     }
 
-    task("submod_" + key + "Jar", type: Jar, dependsOn: "writeFabricModJson_" + key) {
+    task("submod_" + key + "Jar", type: Jar, dependsOn: ["writeFabricModJson_" + key, "remapJar"]) {
 
         archiveBaseName = "$mainName-$key";
         destinationDirectory = extra_jar_def__modulesDir;


### PR DESCRIPTION
# This PR
This pull-request applies the Multi-jar Creation Plugin fixes introduced to LMP to the LNS version of the plugin, thereby enabling use of LNS jars in 1.19 production environments.

# Testing
I have tested this in a small production 1.19 environment and found that it worked correctly.

# Related Issues
This fixes #10