### PR TITLE
Fix CoreMinecraftNetUtil attempting to load client-sided classes

### DIFF
--- a/src/main/java/alexiil/mc/lib/net/impl/CoreMinecraftNetUtil.java
+++ b/src/main/java/alexiil/mc/lib/net/impl/CoreMinecraftNetUtil.java
@@ -16,6 +16,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -165,6 +167,7 @@ public class CoreMinecraftNetUtil {
         );
     }
 
+    @Environment(EnvType.CLIENT)
     public static void loadClient() {
         ClientPlayNetworking.PlayChannelHandler handler = new ClientPlayNetworking.PlayChannelHandler() {
             @Override


### PR DESCRIPTION
# This PR
This pull-request fixes an issue where `CoreMinecraftNetUtil` would attempt to load client-sided classes on a dedicated-server.

# Testing
I have tested this patch on a dedicated server with Wired Redstone and have found that it fixed the issue.

# Related Issues
This was first mentioned in: https://github.com/Kneelawk/WiredRedstone/issues/10