### PR TITLE
0.8.x-1.19.3+ Update buildsystem to 1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.12-SNAPSHOT'
+    id 'fabric-loom' version '1.0-SNAPSHOT'
     id 'org.cadixdev.licenser' version '0.6.1'
 }
 
@@ -20,12 +20,12 @@ loom {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.19"
-    mappings "net.fabricmc:yarn:1.19+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.7"
+    minecraft "com.mojang:minecraft:1.19.3"
+    mappings "net.fabricmc:yarn:1.19.3+build.2:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.11"
 
     //Fabric api
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.55.3+1.19"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.68.1+1.19.3"
 
     // Misc
     compileOnly "com.google.code.findbugs:jsr305:3.0.1"


### PR DESCRIPTION
# This PR
This PR updates the version of Minecraft used to 1.19.3 so any 1.19.3-specific issues can be ironed out.